### PR TITLE
Update ncurses

### DIFF
--- a/community/ncurses.hpkg
+++ b/community/ncurses.hpkg
@@ -22,8 +22,6 @@
                                  " "
                                  "-Wl,-L" (dyn :pkg-out) "/lib"
                                  " "
-                                 "-Wl,--enable-new-dtags"
-                                 " "
                                  "-Wl,-rpath=" (dyn :pkg-out) "/lib"))
     (unpack-src ncurses-src)
     (core/link-/bin/sh)


### PR DESCRIPTION
`--enable-new-dtags` is a default now, so remove it from .hpkg.