### PR TITLE
Update pcre

### DIFF
--- a/community/pcre.hpkg
+++ b/community/pcre.hpkg
@@ -21,12 +21,7 @@
                                  core/make
                                  core/sed]))
      (os/setenv "CFLAGS" *default-cflags*)
-     (os/setenv "LDFLAGS"
-                (string
-                 *default-ldflags*
-                 " "
-                 # use RUNPATH
-                 "-Wl,--enable-new-dtags"))
+     (os/setenv "LDFLAGS" *default-ldflags*)
      (unpack-src pcre-src)
      (core/link-/bin/sh)
      (sh/$ ./configure


### PR DESCRIPTION
--enable-new-dtags is a default now, so remove it from .hpkg.