### PR TITLE
Update talloc

### DIFF
--- a/community/talloc.hpkg
+++ b/community/talloc.hpkg
@@ -16,10 +16,7 @@
                                [core/coreutils core/gcc core/make python3
                                 core/sed core/which]))
     (os/setenv "CFLAGS" *default-cflags*)
-    (os/setenv "LDFLAGS"
-               (string *default-ldflags*
-                       " "
-                       "-Wl,--enable-new-dtags"))
+    (os/setenv "LDFLAGS" *default-ldflags*)
     (unpack-src talloc-src)
     (core/link-/bin/sh)
     # XXX: waf is a python script starting with /usr/bin/env


### PR DESCRIPTION
--enable-new-dtags is a default now, so remove it from .hpkg.