### PR TITLE
Update proot

### DIFF
--- a/community/proot.hpkg
+++ b/community/proot.hpkg
@@ -37,8 +37,6 @@
     (os/setenv "LDFLAGS"
                (string *default-ldflags*
                        " "
-                       "-Wl,--enable-new-dtags"
-                       " "
                        "-L" (talloc :path) "/lib"
                        " "
                        "-Wl,-rpath," (talloc :path) "/lib"))


### PR DESCRIPTION
--enable-new-dtags is a default now, so remove it from .hpkg.