### PR TITLE
Update libevent

### DIFF
--- a/community/libevent.hpkg
+++ b/community/libevent.hpkg
@@ -1,27 +1,26 @@
 (use ../prelude)
 (import ../core)
-(use ./autoconf)
-(use ./automake)
-(use ./libtool)
-(use ./m4)
+(use ./file)
 (use ./python3)
 
 (defsrc libevent-src
-  :file-name
-  "libevent-2.1.11.tar.gz"
   :url
-  "https://github.com/libevent/libevent/archive/release-2.1.11-stable.tar.gz"
+  "https://github.com/libevent/libevent/releases/download/release-2.1.11-stable/libevent-2.1.11-stable.tar.gz"
   :hash
-  "sha256:229393ab2bf0dc94694f21836846b424f3532585bac3468738b7bf752c03901e")
+  "sha256:a65bac6202ea8c5609fd5c7e480e6d25de467ea1917c08290c521752f147283d")
 
 (defpkg libevent
   :builder
   (fn []
     (os/setenv "PATH"
                (join-pkg-paths ":" "/bin"
-                               [autoconf automake core/awk core/coreutils
-                                core/gcc core/grep libtool m4
-                                core/make core/sed]))
+                               [core/awk
+                                core/coreutils
+                                core/diffutils
+                                core/gcc
+                                core/grep
+                                core/make
+                                core/sed]))
     (os/setenv "CFLAGS" *default-cflags*)
     (os/setenv "LDFLAGS" *default-ldflags*)
     (unpack-src libevent-src)
@@ -30,19 +29,14 @@
     (unless (os/lstat "/usr/bin/env")
       (os/symlink (string (core/coreutils :path) "/bin/env")
                   "/usr/bin/env"))
+    # XXX: may end up using system's env for non-chrooted setups
+    (unless (os/lstat "/usr/bin/file")
+      (os/symlink (string (file :path) "/bin/file")
+                  "/usr/bin/file"))
     # XXX: may end up using system's python for non-chrooted setups
     (unless (os/lstat "/usr/bin/python")
       (os/symlink (string (python3 :path) "/bin/python3")
                   "/usr/bin/python"))
-    # XXX: contrary to docs, there was no configure, thus:
-    #        https://askubuntu.com/a/27679
-    (sh/$ libtoolize --force)
-    (sh/$ aclocal)
-    (sh/$ autoheader)
-    (sh/$ automake --force-missing --add-missing)
-    (sh/$ autoconf)
-    # XXX: this didn't work, which is why tried above sequence
-    #(sh/$ ./autogen.sh)
     (sh/$ ./configure
           --prefix= ^ (dyn :pkg-out))
     (sh/$ make -j (dyn :parallelism))


### PR DESCRIPTION
By using a different tarball from the same site, was able to avoid generating a configure script, thus reducing dependencies and build time.  Also updated some of the build-time dependencies which reduced the number of error messages generated by configure.