### PR TITLE
Update libffi

### DIFF
--- a/community/libffi.hpkg
+++ b/community/libffi.hpkg
@@ -1,40 +1,36 @@
 (use ../prelude)
 (import ../core)
-(use ./autoconf)
-(use ./automake)
-(use ./libtool)
-(use ./m4)
-(use ./perl)
-(use ./texinfo)
+(use ./file)
 
 (defsrc libffi-src
-  :file-name
-  "libffi-3.3.tar.gz"
   :url
-  "https://github.com/libffi/libffi/archive/v3.3.tar.gz"
+  "https://github.com/libffi/libffi/releases/download/v3.3/libffi-3.3.tar.gz"
   :hash
-  "sha256:3f2f86094f5cf4c36cfe850d2fe029d01f5c2c2296619407c8ba0d8207da9a6b")
+  "sha256:72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056")
 
 (defpkg libffi
   :builder
   (fn []
-    (os/setenv "ACLOCAL_PATH"
-      (string (libtool :path) "/share/aclocal"))
     (os/setenv "PATH"
                (string "/bin:" # for finding sh
                        (join-pkg-paths ":" "/bin"
-                                       [autoconf automake core/awk
-                                        core/coreutils core/diffutils
-                                        core/gcc core/grep libtool
-                                        core/make m4 perl core/sed
-                                        core/tar texinfo])))
+                                       [core/awk
+                                        core/coreutils
+                                        core/diffutils
+                                        core/gcc
+                                        core/grep
+                                        core/make
+                                        core/sed])))
     (os/setenv "CFLAGS" *default-cflags*)
     (os/setenv "LDFLAGS" *default-ldflags*)
     (unpack-src libffi-src)
     (core/link-/bin/sh)
-    (sh/$ ./autogen.sh)
+    # XXX: may end up using system's env for non-chrooted setups
+    (unless (os/lstat "/usr/bin/file")
+      (os/symlink (string (file :path) "/bin/file")
+                  "/usr/bin/file"))
     (sh/$ ./configure
           --prefix= ^ (dyn :pkg-out))
-    (sh/$ make -j
-          (dyn :parallelism))
+    (sh/$ make
+          -j (dyn :parallelism))
     (sh/$ make install)))


### PR DESCRIPTION
By using a different tarball from the same site, was able to avoid generating a configure script, thus reducing dependencies and build time.  Also added a build-time dependency to reduce errors from configure.